### PR TITLE
v2.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ subprojects {
         }
         compileOnly("com.zaxxer:HikariCP:7.0.2")
         compileOnly("org.xerial:sqlite-jdbc:3.49.1.0")
-        compileOnly("org.mariadb.jdbc:mariadb-java-client:3.5.2")
+        compileOnly("org.mariadb.jdbc:mariadb-java-client:3.5.5 ")
         compileOnly("com.github.ben-manes.caffeine:caffeine:3.1.8")
         compileOnly("io.github.g00fy2:versioncompare:1.5.0")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "nl.chimpgamer.ultimatemobcoins"
-    version = "2.0.0-SNAPSHOT"
+    version = "2.0.0"
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "nl.chimpgamer.ultimatemobcoins"
-    version = "1.8.2"
+    version = "2.0.0-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ subprojects {
         }
         compileOnly("com.zaxxer:HikariCP:7.0.2")
         compileOnly("org.xerial:sqlite-jdbc:3.49.1.0")
-        compileOnly("org.mariadb.jdbc:mariadb-java-client:3.5.5 ")
+        compileOnly("org.mariadb.jdbc:mariadb-java-client:3.5.6")
         compileOnly("com.github.ben-manes.caffeine:caffeine:3.1.8")
         compileOnly("io.github.g00fy2:versioncompare:1.5.0")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ subprojects {
         compileOnly("org.jetbrains.exposed:exposed-jdbc:$exposedVersion") {
             exclude("org.jetbrains.kotlin")
         }
-        compileOnly("com.zaxxer:HikariCP:6.1.0")
+        compileOnly("com.zaxxer:HikariCP:7.0.2")
         compileOnly("org.xerial:sqlite-jdbc:3.49.1.0")
         compileOnly("org.mariadb.jdbc:mariadb-java-client:3.5.2")
         compileOnly("com.github.ben-manes.caffeine:caffeine:3.1.8")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ subprojects {
 
         compileOnly("dev.dejvokep:boosted-yaml:1.3.7")
         compileOnly("org.incendo:cloud-core:2.0.0")
-        compileOnly("org.incendo:cloud-minecraft-extras:2.0.0-beta.10")
+        compileOnly("org.incendo:cloud-minecraft-extras:2.0.0-beta.13")
         compileOnly("org.incendo:cloud-kotlin-coroutines:2.0.0")
 
         compileOnly("org.jetbrains.exposed:exposed-core:$exposedVersion") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import java.util.*
 val exposedVersion = "0.60.0"
 
 plugins {
-    kotlin("jvm") version "2.2.0"
+    kotlin("jvm") version "2.2.10"
     id("com.gradleup.shadow") version "8.3.5"
     `maven-publish`
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "nl.chimpgamer.ultimatemobcoins"
-    version = "1.8.1"
+    version = "1.8.2"
 
     repositories {
         mavenCentral()

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -27,8 +27,8 @@ repositories {
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT")
 
-    compileOnly("io.github.miniplaceholders:miniplaceholders-api:2.2.3")
-    compileOnly("io.github.miniplaceholders:miniplaceholders-kotlin-ext:2.2.3")
+    compileOnly("io.github.miniplaceholders:miniplaceholders-api:3.0.1")
+    compileOnly("io.github.miniplaceholders:miniplaceholders-kotlin-ext:3.0.1")
 
     compileOnly("org.incendo:cloud-paper:2.0.0-beta.10")
 

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
 
     compileOnly("io.github.miniplaceholders:miniplaceholders-api:3.0.1")
     compileOnly("io.github.miniplaceholders:miniplaceholders-kotlin-ext:3.0.1")

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     compileOnly("io.github.miniplaceholders:miniplaceholders-api:3.0.1")
     compileOnly("io.github.miniplaceholders:miniplaceholders-kotlin-ext:3.0.1")
 
-    compileOnly("org.incendo:cloud-paper:2.0.0-beta.10")
+    compileOnly("org.incendo:cloud-paper:2.0.0-beta.13")
 
     compileOnly("dev.rosewood:rosestacker:1.5.30")
     compileOnly("com.arcaniax:HeadDatabase-API:1.3.2")

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     compileOnly("org.betonquest:betonquest:2.2.1") { isTransitive = false }
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.8") // WorldGuard
     compileOnly("io.github.rysefoxx.inventory:RyseInventory-Plugin:1.6.13")
-    compileOnly("com.nexomc:nexo:1.3.0")
+    compileOnly("com.nexomc:nexo:1.10.0")
 
     implementation("com.github.shynixn.mccoroutine:mccoroutine-folia-api:2.22.0") { isTransitive = false }
     implementation("com.github.shynixn.mccoroutine:mccoroutine-folia-core:2.22.0") { isTransitive = false }

--- a/paper/src/main/java/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsLoader.java
+++ b/paper/src/main/java/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsLoader.java
@@ -15,7 +15,7 @@ public class UltimateMobCoinsLoader implements PluginLoader {
     @Override
     public void classloader(@NotNull PluginClasspathBuilder classpathBuilder) {
         var dependencies = new ArrayList<String>() {{
-            add("org.jetbrains.kotlin:kotlin-stdlib:2.2.0");
+            add("org.jetbrains.kotlin:kotlin-stdlib:2.2.10");
             add("org.jetbrains.exposed:exposed-core:0.60.0");
             add("org.jetbrains.exposed:exposed-dao:0.60.0");
             add("org.jetbrains.exposed:exposed-jdbc:0.60.0");

--- a/paper/src/main/java/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsLoader.java
+++ b/paper/src/main/java/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsLoader.java
@@ -22,8 +22,8 @@ public class UltimateMobCoinsLoader implements PluginLoader {
             add("org.xerial:sqlite-jdbc:3.49.1.0");
             add("org.mariadb.jdbc:mariadb-java-client:3.5.5");
             add("org.incendo:cloud-core:2.0.0");
-            add("org.incendo:cloud-paper:2.0.0-beta.10");
-            add("org.incendo:cloud-minecraft-extras:2.0.0-beta.10");
+            add("org.incendo:cloud-paper:2.0.0-beta.13");
+            add("org.incendo:cloud-minecraft-extras:2.0.0-beta.13");
             add("org.incendo:cloud-kotlin-coroutines:2.0.0");
             add("dev.dejvokep:boosted-yaml:1.3.7");
             add("io.github.rysefoxx.inventory:RyseInventory-Plugin:1.6.13");

--- a/paper/src/main/java/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsLoader.java
+++ b/paper/src/main/java/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsLoader.java
@@ -20,7 +20,7 @@ public class UltimateMobCoinsLoader implements PluginLoader {
             add("org.jetbrains.exposed:exposed-dao:0.60.0");
             add("org.jetbrains.exposed:exposed-jdbc:0.60.0");
             add("org.xerial:sqlite-jdbc:3.49.1.0");
-            add("org.mariadb.jdbc:mariadb-java-client:3.5.5");
+            add("org.mariadb.jdbc:mariadb-java-client:3.5.6");
             add("org.incendo:cloud-core:2.0.0");
             add("org.incendo:cloud-paper:2.0.0-beta.13");
             add("org.incendo:cloud-minecraft-extras:2.0.0-beta.13");

--- a/paper/src/main/java/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsLoader.java
+++ b/paper/src/main/java/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsLoader.java
@@ -28,7 +28,7 @@ public class UltimateMobCoinsLoader implements PluginLoader {
             add("dev.dejvokep:boosted-yaml:1.3.7");
             add("io.github.rysefoxx.inventory:RyseInventory-Plugin:1.6.13");
             add("com.github.ben-manes.caffeine:caffeine:3.1.8");
-            add("com.zaxxer:HikariCP:6.1.0");
+            add("com.zaxxer:HikariCP:7.0.2");
             add("org.postgresql:postgresql:42.7.5");
 
             add("org.mongodb:mongodb-driver-core:5.4.0");

--- a/paper/src/main/java/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsLoader.java
+++ b/paper/src/main/java/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsLoader.java
@@ -20,7 +20,7 @@ public class UltimateMobCoinsLoader implements PluginLoader {
             add("org.jetbrains.exposed:exposed-dao:0.60.0");
             add("org.jetbrains.exposed:exposed-jdbc:0.60.0");
             add("org.xerial:sqlite-jdbc:3.49.1.0");
-            add("org.mariadb.jdbc:mariadb-java-client:3.5.2");
+            add("org.mariadb.jdbc:mariadb-java-client:3.5.5");
             add("org.incendo:cloud-core:2.0.0");
             add("org.incendo:cloud-paper:2.0.0-beta.10");
             add("org.incendo:cloud-minecraft-extras:2.0.0-beta.10");

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsPlugin.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsPlugin.kt
@@ -167,7 +167,8 @@ class UltimateMobCoinsPlugin : SuspendingJavaPlugin() {
             val shopFiles = listOf(
                 "main_menu.yml",
                 "rotating_shop.yml",
-                "shop.yml"
+                "shop.yml",
+                "shop_with_timer.yml"
             )
             for (shopFile in shopFiles) {
                 val inJarPath = "shops/$shopFile"

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsPlugin.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsPlugin.kt
@@ -35,9 +35,7 @@ import nl.chimpgamer.ultimatemobcoins.paper.utils.LogWriter
 import nl.chimpgamer.ultimatemobcoins.paper.utils.updatechecker.ModrinthUpdateChecker
 import org.bstats.bukkit.Metrics
 import org.bstats.charts.SimplePie
-import org.bukkit.NamespacedKey
 import org.bukkit.configuration.file.YamlConfiguration
-import org.bukkit.enchantments.Enchantment
 import org.bukkit.event.Event
 import org.bukkit.event.entity.EntityDeathEvent
 import org.bukkit.event.entity.EntitySpawnEvent
@@ -73,12 +71,6 @@ class UltimateMobCoinsPlugin : SuspendingJavaPlugin() {
     private val inventoryManager = InventoryManager(this)
 
     val logWriter = LogWriter(this)
-
-    val lootingEnchantment: Enchantment = try {
-        Enchantment.LOOT_BONUS_MOBS
-    } catch (ex: NoSuchFieldError) {
-        Enchantment.getByKey(NamespacedKey.minecraft("looting"))!!
-    }
 
     val modrinthUpdateChecker = ModrinthUpdateChecker(this)
 

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/commands/MobCoinsCommand.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/commands/MobCoinsCommand.kt
@@ -19,6 +19,7 @@ import org.bukkit.OfflinePlayer
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 import org.incendo.cloud.CommandManager
+import org.incendo.cloud.component.CommandComponent
 import org.incendo.cloud.component.DefaultValue
 import org.incendo.cloud.key.CloudKey
 import org.incendo.cloud.kotlin.coroutines.extension.suspendingHandler
@@ -53,11 +54,19 @@ class MobCoinsCommand(private val plugin: UltimateMobCoinsPlugin) {
         val minimumKey = CloudKey.of("minimum", Double::class.java)
         val maximumKey = CloudKey.of("maximum", Double::class.java)
 
+        val withdrawAmountArgument = if (plugin.settingsConfig.commandWithdrawAmountDoubleType) {
+            CommandComponent.builder<CommandSender, Double>()
+                .parser(doubleParser(0.1, plugin.settingsConfig.commandWithdrawAmountMax))
+        } else {
+            CommandComponent.builder<CommandSender, Int>()
+                .parser(integerParser(1, plugin.settingsConfig.commandWithdrawAmountMax.toInt()))
+        }.name("amount").required().build()
+
         val silentFlag = commandManager.flagBuilder("silent").withAliases("s").build()
 
         val optionalShopArgument = MenuParser.menuComponent<CommandSender>()
             .name("menu")
-            .optional(DefaultValue.dynamic { ctx -> plugin.shopMenus[plugin.settingsConfig.commandDefaultShop]!! })
+            .optional(DefaultValue.dynamic { _ -> plugin.shopMenus[plugin.settingsConfig.commandDefaultShop]!! })
             .build()
 
         val requiredShopArgument = MenuParser.menuComponent<CommandSender>()
@@ -449,7 +458,7 @@ class MobCoinsCommand(private val plugin: UltimateMobCoinsPlugin) {
             .senderType(Player::class.java)
             .literal("withdraw")
             .permission("$basePermission.withdraw")
-            .required(amountKey, doubleParser(0.1))
+            .argument(withdrawAmountArgument)
             .suspendingHandler { context ->
                 val sender = context.sender()
                 val user = plugin.userManager.getUser(sender.uniqueId)
@@ -457,18 +466,19 @@ class MobCoinsCommand(private val plugin: UltimateMobCoinsPlugin) {
                     plugin.logger.warning("Something went wrong! Could not get user ${sender.name} (${sender.uniqueId})")
                     return@suspendingHandler
                 }
-                val amount = context[amountKey]
-                if (!user.hasEnough(amount.toBigDecimal())) {
-                    sender.sendMessage(plugin.messagesConfig.mobCoinsNotEnough.parse(mapOf("amount" to amount)))
+                val amount = context[withdrawAmountArgument]
+                val bigDecimalAmount = amount.toDouble().toBigDecimal(MathContext(3))
+                val amountAsDouble = bigDecimalAmount.toDouble()
+
+                if (!user.hasEnough(bigDecimalAmount)) {
+                    sender.sendMessage(plugin.messagesConfig.mobCoinsNotEnough.parse(mapOf("amount" to amountAsDouble)))
                     return@suspendingHandler
                 }
                 if (sender.inventory.firstEmpty() == -1) {
                     sender.sendMessage(plugin.messagesConfig.mobCoinsInventoryFull.parse())
                     return@suspendingHandler
                 }
-                val finalAmount = amount.toBigDecimal(MathContext(3))
-                user.withdrawCoins(finalAmount)
-                val amountAsDouble = finalAmount.toDouble()
+                user.withdrawCoins(bigDecimalAmount)
 
                 val amountPlaceholder = Placeholder.unparsed("amount", amountAsDouble.toString())
                 val mobCoinItem = plugin.settingsConfig.getMobCoinsItem(amountPlaceholder)

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/MenuConfig.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/MenuConfig.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.KClass
 class MenuConfig(plugin: UltimateMobCoinsPlugin, val file: File) {
     val config: YamlDocument
 
-    val menuType: MenuType get() = config.getEnum("type", MenuType::class.java, MenuType.NORMAL)
+    val menuType: MenuType get() = getEnum("type", MenuType::class, MenuType.NORMAL)
 
     fun hasResetTimer(): Boolean {
         val refreshTime = config.getLong("refresh_time")

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/SettingsConfig.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/SettingsConfig.kt
@@ -61,6 +61,9 @@ class SettingsConfig(private val plugin: UltimateMobCoinsPlugin) {
     val commandAliases: List<String> get() = config.getStringList("command.aliases")
     val commandDefaultShop: String get() = config.getString("command.default_shop")
 
+    val commandWithdrawAmountDoubleType: Boolean get() = config.getBoolean("command.withdraw.amount.double-type", true)
+    val commandWithdrawAmountMax: Double get() = config.getDouble("command.withdraw.amount.max", Double.MAX_VALUE)
+
     val updateNotifyOnJoin: Boolean get() = config.getBoolean("update.notify-on-join", true)
 
     val debug: Boolean get() = config.getBoolean("debug", false)

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/SettingsConfig.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/SettingsConfig.kt
@@ -46,6 +46,12 @@ class SettingsConfig(private val plugin: UltimateMobCoinsPlugin) {
     val mobCoinsLeaderboardEnabled: Boolean get() = config.getBoolean("mobcoins.leaderboard.enabled", false)
     val mobCoinsLeaderboardShowZero: Boolean get() = config.getBoolean("mobcoins.leaderboard.show-zero", false)
     val mobCoinsAnimationsDrop: ConfigurableAnimation get() = ConfigurableAnimation.deserialize(config.getSection("mobcoins.animations.drop").getStringRouteMappedValues(false))
+    val mobCoinsEarningsPenaltyEnabled: Boolean get() = config.getBoolean("mobcoins.earnings-penalty.enabled", false)
+    val mobCoinsEarningsPenaltyThreshold: Double get() = config.getDouble("mobcoins.earnings-penalty.threshold", 0.0)
+    val mobCoinsEarningsPenaltyCooldownValue: Long get() = config.getLong("mobcoins.earnings-penalty.cooldown.value", 1)
+    val mobCoinsEarningsPenaltyCooldownUnit: String get() = config.getString("mobcoins.earnings-penalty.cooldown.unit", "minutes")
+    val mobCoinsEarningsPenaltyType: String get() = config.getString("mobcoins.earnings-penalty.type", "percentage")
+    val mobCoinsEarningsPenaltyValue: Double get() = config.getDouble("mobcoins.earnings-penalty.value", 0.0)
 
     val logPay: Boolean get() = config.getBoolean("log.pay")
     val logWithdraw: Boolean get() = config.getBoolean("log.withdraw")

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/extensions/ItemStackExt.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/extensions/ItemStackExt.kt
@@ -12,7 +12,6 @@ import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.*
 import org.bukkit.material.Colorable
-import org.bukkit.potion.PotionData
 import org.bukkit.potion.PotionType
 import java.util.*
 import kotlin.collections.ArrayList
@@ -163,10 +162,10 @@ fun ItemStack.customSkull(data: String): ItemStack {
     return this
 }
 
-fun ItemStack.potion(potionType: PotionType, extended: Boolean = false, upgraded: Boolean = false): ItemStack {
+fun ItemStack.potion(potionType: PotionType): ItemStack {
     meta {
         if (this is PotionMeta) {
-            this.basePotionData = PotionData(potionType, extended, upgraded)
+            this.basePotionType = potionType
         }
     }
     return this

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/extensions/MiniMessageExt.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/extensions/MiniMessageExt.kt
@@ -18,12 +18,12 @@ private val miniMessageTagRegex = Regex("<[!?#]?[a-z0-9_-]*>")
 fun String.parse() = miniMessage().deserialize(this).decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
 
 fun String.parse(tagResolver: TagResolver) = miniMessage().deserialize(this, tagResolver).decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
-fun String.parse(player: Player?, tagResolver: TagResolver) = miniMessage().deserialize(this,
+fun String.parse(player: Player, tagResolver: TagResolver) = miniMessage().deserialize(this, player,
     TagResolver.resolver(placeholderAPIPlaceholdersToTagResolver(player), miniPlaceholdersToTagResolver(player), tagResolver)
 ).decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
 
 fun String.parse(replacements: Map<String, *>) = parse(replacements.toTagResolver())
-fun String.parse(player: Player?, replacements: Map<String, *>) = parse(player, replacements.toTagResolver())
+fun String.parse(player: Player, replacements: Map<String, *>) = parse(player, replacements.toTagResolver())
 
 fun String.isValid(): Boolean = miniMessage().deserializeOrNull(this) != null
 
@@ -40,9 +40,9 @@ fun Map<String, *>.toTagResolver(parsed: Boolean = false) = TagResolver.resolver
 internal fun miniPlaceholdersToTagResolver(player: Player?): TagResolver {
     if (isMiniPlaceholders) {
         return if (player == null) {
-            MiniPlaceholders.getGlobalPlaceholders()
+            MiniPlaceholders.globalPlaceholders()
         } else {
-            MiniPlaceholders.getAudienceGlobalPlaceholders(player)
+            MiniPlaceholders.audienceGlobalPlaceholders()
         }
     }
     return TagResolver.empty()

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/ItemsAdderHook.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/ItemsAdderHook.kt
@@ -1,0 +1,42 @@
+package nl.chimpgamer.ultimatemobcoins.paper.hooks
+
+import dev.lone.itemsadder.api.CustomStack
+import dev.lone.itemsadder.api.Events.ItemsAdderLoadDataEvent
+import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.HandlerList
+import org.bukkit.event.Listener
+import org.bukkit.inventory.ItemStack
+
+class ItemsAdderHook(plugin: UltimateMobCoinsPlugin) : PluginHook(plugin, "ItemsAdder") {
+    private lateinit var itemsAdderItemsLoadedEventListener: Listener
+
+    override fun load() {
+        if (isLoaded) return
+        if (!canHook()) return
+
+        itemsAdderItemsLoadedEventListener = object : Listener {
+            @EventHandler(priority = EventPriority.MONITOR)
+            fun onItemsAdderLoadData(event: ItemsAdderLoadDataEvent) {
+                plugin.shopMenus.values.forEach { it.loadAllItems() }
+                plugin.debug { "[ItemsAdderLoadDataEvent] Reloaded items of all shop menus" }
+            }
+        }
+        plugin.server.pluginManager.registerEvents(itemsAdderItemsLoadedEventListener, plugin)
+        isLoaded = true
+        plugin.logger.info("Successfully loaded $pluginName hook!")
+    }
+
+    override fun unload() {
+        if (this::itemsAdderItemsLoadedEventListener.isInitialized) {
+            HandlerList.unregisterAll(itemsAdderItemsLoadedEventListener)
+        }
+        isLoaded = false
+    }
+
+    fun itemsAdderItem(id: String): ItemStack? {
+        if (!isLoaded) return null
+        return CustomStack.getInstance(id)?.itemStack
+    }
+}

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/MiniPlaceholdersHook.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/MiniPlaceholdersHook.kt
@@ -1,6 +1,7 @@
 package nl.chimpgamer.ultimatemobcoins.paper.hooks
 
 import io.github.miniplaceholders.api.Expansion
+import io.github.miniplaceholders.kotlin.audience
 import net.kyori.adventure.text.minimessage.tag.Tag
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
 import nl.chimpgamer.ultimatemobcoins.paper.models.menu.RefreshableShopMenu
@@ -14,8 +15,6 @@ class MiniPlaceholdersHook(plugin: UltimateMobCoinsPlugin) : PluginHook(plugin, 
         if (!canHook()) return
 
         expansion = Expansion.builder("ultimatemobcoins")
-            .filter(Player::class.java)
-
             .globalPlaceholder("shop_refresh_time") { argumentQueue, _ ->
                 val shopName = argumentQueue.popOr("shop_refresh_time tag requires a valid rotating shop name.").value()
                 val menu = plugin.shopMenus[shopName] ?: return@globalPlaceholder null
@@ -56,79 +55,64 @@ class MiniPlaceholdersHook(plugin: UltimateMobCoinsPlugin) : PluginHook(plugin, 
                     )
                 } ?: Tag.preProcessParsed("...")
             }
-            .audiencePlaceholder("balance") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("balance") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(user.coinsAsDouble.toString())
             }
-            .audiencePlaceholder("balance_formatted") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("balance_formatted") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(user.coinsPretty)
             }
-            .audiencePlaceholder("balance_fixed") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("balance_fixed") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(NumberFormatter.FIXED_FORMAT.format(user.coinsAsDouble))
             }
-            .audiencePlaceholder("balance_commas") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("balance_commas") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(NumberFormatter.COMMAS_FORMAT.format(user.coinsAsDouble))
             }
-            .audiencePlaceholder("balance_formatted_compact") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("balance_formatted_compact") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(NumberFormatter.compactDecimalFormat(user.coins))
             }
-            .audiencePlaceholder("collected") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("collected") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(user.coinsCollectedAsDouble.toString())
             }
-            .audiencePlaceholder("collected_formatted") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("collected_formatted") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(user.coinsCollectedPretty)
             }
-            .audiencePlaceholder("collected_fixed") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("collected_fixed") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(NumberFormatter.FIXED_FORMAT.format(user.coinsCollectedAsDouble))
             }
-            .audiencePlaceholder("collected_commas") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("collected_commas") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(NumberFormatter.COMMAS_FORMAT.format(user.coinsCollectedAsDouble))
             }
-            .audiencePlaceholder("collected_formatted_compact") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("collected_formatted_compact") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(NumberFormatter.compactDecimalFormat(user.coinsCollected))
             }
-            .audiencePlaceholder("spent") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("spent") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(user.coinsSpentAsDouble.toString())
             }
-            .audiencePlaceholder("spent_formatted") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("spent_formatted") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(user.coinsSpentPretty)
             }
-            .audiencePlaceholder("spent_fixed") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("spent_fixed") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(NumberFormatter.FIXED_FORMAT.format(user.coinsSpentAsDouble))
             }
-            .audiencePlaceholder("spent_commas") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("spent_commas") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(NumberFormatter.COMMAS_FORMAT.format(user.coinsSpentAsDouble))
             }
-            .audiencePlaceholder("spent_formatted_compact") { audience, _, _ ->
-                audience as Player
-                val user = plugin.userManager.getIfLoaded(audience) ?: return@audiencePlaceholder null
+            .audience<Player>("spent_formatted_compact") { audience, _, _ ->
+                val user = plugin.userManager.getIfLoaded(audience) ?: return@audience null
                 Tag.preProcessParsed(NumberFormatter.compactDecimalFormat(user.coinsSpent))
             }
             .build()

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/NexoHook.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/NexoHook.kt
@@ -1,0 +1,42 @@
+package nl.chimpgamer.ultimatemobcoins.paper.hooks
+
+import com.nexomc.nexo.api.NexoItems
+import com.nexomc.nexo.api.events.NexoItemsLoadedEvent
+import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.HandlerList
+import org.bukkit.event.Listener
+import org.bukkit.inventory.ItemStack
+
+class NexoHook(plugin: UltimateMobCoinsPlugin) : PluginHook(plugin, "Nexo") {
+    private lateinit var nexoItemsLoadedEventListener: Listener
+
+    override fun load() {
+        if (isLoaded) return
+        if (!canHook()) return
+
+        nexoItemsLoadedEventListener = object : Listener {
+            @EventHandler(priority = EventPriority.MONITOR)
+            fun onNexoItemsLoaded(event: NexoItemsLoadedEvent) {
+                plugin.shopMenus.values.forEach { it.loadAllItems() }
+                plugin.debug { "[NexoItemsLoadedEvent] Reloaded items of all shop menus" }
+            }
+        }
+        plugin.server.pluginManager.registerEvents(nexoItemsLoadedEventListener, plugin)
+        isLoaded = true
+        plugin.logger.info("Successfully loaded $pluginName hook!")
+    }
+
+    override fun unload() {
+        if (this::nexoItemsLoadedEventListener.isInitialized) {
+            HandlerList.unregisterAll(nexoItemsLoadedEventListener)
+        }
+        isLoaded = false
+    }
+
+    fun nexoItem(id: String): ItemStack? {
+        if (!isLoaded) return null
+        return NexoItems.itemFromId(id)?.build()
+    }
+}

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/OraxenHook.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/OraxenHook.kt
@@ -1,0 +1,42 @@
+package nl.chimpgamer.ultimatemobcoins.paper.hooks
+
+import io.th0rgal.oraxen.api.OraxenItems
+import io.th0rgal.oraxen.api.events.OraxenItemsLoadedEvent
+import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.HandlerList
+import org.bukkit.event.Listener
+import org.bukkit.inventory.ItemStack
+
+class OraxenHook(plugin: UltimateMobCoinsPlugin) : PluginHook(plugin, "Oraxen") {
+    private lateinit var oraxenItemsLoadedEventListener: Listener
+
+    override fun load() {
+        if (isLoaded) return
+        if (!canHook()) return
+
+        oraxenItemsLoadedEventListener = object : Listener {
+            @EventHandler(priority = EventPriority.MONITOR)
+            fun onOraxenItemsLoaded(event: OraxenItemsLoadedEvent) {
+                plugin.shopMenus.values.forEach { it.loadAllItems() }
+                plugin.debug { "[OraxenItemsLoadedEvent] Reloaded items of all shop menus" }
+            }
+        }
+        plugin.server.pluginManager.registerEvents(oraxenItemsLoadedEventListener, plugin)
+        isLoaded = true
+        plugin.logger.info("Successfully loaded $pluginName hook!")
+    }
+
+    override fun unload() {
+        if (this::oraxenItemsLoadedEventListener.isInitialized) {
+            HandlerList.unregisterAll(oraxenItemsLoadedEventListener)
+        }
+        isLoaded = false
+    }
+
+    fun oraxenItem(id: String): ItemStack? {
+        if (!isLoaded) return null
+        return OraxenItems.getItemById(id)?.build()
+    }
+}

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/PlaceholderAPIHook.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/PlaceholderAPIHook.kt
@@ -35,13 +35,10 @@ class PlaceholderAPIHook(private val plugin: UltimateMobCoinsPlugin) : Placehold
 
         if (params.startsWith("leaderboard_mobcoins_", ignoreCase = true)) {
             val newParams = params.replaceFirst("leaderboard_mobcoins_", "")
-            val position = newParams.substring(0, newParams.indexOfFirst { it == '_' }).toInt()
+            val position = newParams.take(newParams.indexOfFirst { it == '_' }).toInt()
 
             val type = newParams.replaceFirst("${position}_", "")
-            val user = plugin.leaderboardManager.getTopMobCoinsPosition(position)
-            if (user == null) {
-                return "..."
-            }
+            val user = plugin.leaderboardManager.getTopMobCoinsPosition(position) ?: return "..."
             return when (type.lowercase()) {
                 "name" -> user.username
                 "value" -> user.coins.toString()
@@ -51,13 +48,10 @@ class PlaceholderAPIHook(private val plugin: UltimateMobCoinsPlugin) : Placehold
         }
         if (params.startsWith("leaderboard_mobcoins_grind_", ignoreCase = true)) {
             val newParams = params.replaceFirst("leaderboard_mobcoins_grind_", "")
-            val position = newParams.substring(0, newParams.indexOfFirst { it == '_' }).toInt()
+            val position = newParams.take(newParams.indexOfFirst { it == '_' }).toInt()
 
             val type = newParams.replaceFirst("${position}_", "")
-            val user = plugin.leaderboardManager.getTopMobCoinsGrindPosition(position)
-            if (user == null) {
-                return "..."
-            }
+            val user = plugin.leaderboardManager.getTopMobCoinsGrindPosition(position) ?: return "..."
             return when (type.lowercase()) {
                 "name" -> user.username
                 "value" -> user.coins.toString()

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/RoseStackerHook.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/hooks/RoseStackerHook.kt
@@ -4,11 +4,12 @@ import com.github.shynixn.mccoroutine.folia.entityDispatcher
 import dev.rosewood.rosestacker.api.RoseStackerAPI
 import dev.rosewood.rosestacker.config.SettingKey
 import dev.rosewood.rosestacker.event.EntityStackMultipleDeathEvent
+import io.papermc.paper.registry.RegistryAccess
+import io.papermc.paper.registry.RegistryKey
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.registerSuspendingEvents
 import nl.chimpgamer.ultimatemobcoins.paper.listeners.RoseStackerListener
 import org.bukkit.NamespacedKey
-import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.LivingEntity
 import org.bukkit.event.HandlerList
 import org.bukkit.event.entity.EntityDeathEvent
@@ -66,7 +67,8 @@ class RoseStackerHook(plugin: UltimateMobCoinsPlugin) : PluginHook(plugin, "Rose
 
         if (killer == null) return false
 
-        val enchantment = Enchantment.getByKey(NamespacedKey.fromString(SettingKey.ENTITY_MULTIKILL_ENCHANTMENT_TYPE.get())) ?: return false
+        val enchantmentNamespacedKey = NamespacedKey.fromString(SettingKey.ENTITY_MULTIKILL_ENCHANTMENT_TYPE.get()) ?: return false
+        val enchantment = RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT).get(enchantmentNamespacedKey) ?: return false
 
         return killer.inventory.itemInMainHand.getEnchantmentLevel(enchantment) > 0
     }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/EntityListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/EntityListener.kt
@@ -77,10 +77,10 @@ class EntityListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
         if (!prepareMobCoinDropEvent.callEvent()) return
 
         var dropAmount = plugin.mobCoinsManager.getCoinDropAmount(killer, mobCoin, dropsMultiplier) ?: return
+        dropAmount = plugin.mobCoinsManager.checkRecentEarnings(killer, dropAmount)
+
         var mobCoinItem = plugin.mobCoinsManager.createMobCoinItem(dropAmount)
         if (drops.any { it.type === mobCoinItem.type }) return
-
-        dropAmount = plugin.mobCoinsManager.checkRecentEarnings(killer, dropAmount)
 
         val mobCoinDropEvent = MobCoinDropEvent(killer, user, entity, dropAmount, mobCoinItem, isAsynchronous)
         if (!mobCoinDropEvent.callEvent()) return

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/EntityListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/EntityListener.kt
@@ -2,6 +2,9 @@ package nl.chimpgamer.ultimatemobcoins.paper.listeners
 
 import com.github.shynixn.mccoroutine.folia.entityDispatcher
 import com.github.shynixn.mccoroutine.folia.launch
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import com.github.shynixn.mccoroutine.folia.ticks
 import kotlinx.coroutines.delay
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
@@ -19,8 +22,12 @@ import org.bukkit.event.Listener
 import org.bukkit.event.entity.EntityDeathEvent
 import org.bukkit.event.entity.ItemSpawnEvent
 import org.bukkit.metadata.FixedMetadataValue
+import java.math.MathContext
 
 class EntityListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
+    private val recentEarnings = mutableMapOf<String, MutableList<EarningEntry>>()
+
+    private data class EarningEntry(val amount: BigDecimal, val timestamp: Instant)
 
     @EventHandler(ignoreCancelled = true)
     suspend fun EntityDeathEvent.onEntityDeath() {
@@ -76,9 +83,11 @@ class EntityListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
         )
         if (!prepareMobCoinDropEvent.callEvent()) return
 
-        val dropAmount = plugin.mobCoinsManager.getCoinDropAmount(killer, mobCoin, dropsMultiplier) ?: return
+        var dropAmount = plugin.mobCoinsManager.getCoinDropAmount(killer, mobCoin, dropsMultiplier) ?: return
         var mobCoinItem = plugin.mobCoinsManager.createMobCoinItem(dropAmount)
         if (drops.any { it.type === mobCoinItem.type }) return
+
+        dropAmount = plugin.mobCoinsManager.checkRecentEarnings(killer, dropAmount)
 
         val mobCoinDropEvent = MobCoinDropEvent(killer, user, entity, dropAmount, mobCoinItem, isAsynchronous)
         if (!mobCoinDropEvent.callEvent()) return
@@ -87,6 +96,7 @@ class EntityListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
 
         if (prepareMobCoinDropEvent.autoPickup) {
             if (!MobCoinsReceiveEvent(killer, user, dropAmount).callEvent()) return
+
             user.depositCoins(dropAmount)
             user.addCoinsCollected(dropAmount)
             val dropAmountPretty = NumberFormatter.displayCurrency(dropAmount)

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/EntityListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/EntityListener.kt
@@ -2,9 +2,6 @@ package nl.chimpgamer.ultimatemobcoins.paper.listeners
 
 import com.github.shynixn.mccoroutine.folia.entityDispatcher
 import com.github.shynixn.mccoroutine.folia.launch
-import java.math.BigDecimal
-import java.time.Instant
-import java.time.temporal.ChronoUnit
 import com.github.shynixn.mccoroutine.folia.ticks
 import kotlinx.coroutines.delay
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
@@ -22,12 +19,8 @@ import org.bukkit.event.Listener
 import org.bukkit.event.entity.EntityDeathEvent
 import org.bukkit.event.entity.ItemSpawnEvent
 import org.bukkit.metadata.FixedMetadataValue
-import java.math.MathContext
 
 class EntityListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
-    private val recentEarnings = mutableMapOf<String, MutableList<EarningEntry>>()
-
-    private data class EarningEntry(val amount: BigDecimal, val timestamp: Instant)
 
     @EventHandler(ignoreCancelled = true)
     suspend fun EntityDeathEvent.onEntityDeath() {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/PlayerInteractListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/PlayerInteractListener.kt
@@ -41,7 +41,13 @@ class PlayerInteractListener(private val plugin: UltimateMobCoinsPlugin) : Liste
         if (!MobCoinsRedeemEvent(player, user, amount).callEvent()) return
         user.depositCoins(amount)
         player.inventory.setItemInMainHand(null)
-        plugin.messagesConfig.mobCoinsReceivedActionBar.takeIf { it.isNotEmpty() }?.let { player.sendActionBar(it.parse(mapOf("amount" to NumberFormatter.displayCurrency(amount)))) }
+        val amountPretty = NumberFormatter.displayCurrency(amount)
+        plugin.messagesConfig.mobCoinsReceivedChat
+            .takeIf { it.isNotEmpty() }
+            ?.let { player.sendMessage(it.parse(mapOf("amount" to amountPretty))) }
+        plugin.messagesConfig.mobCoinsReceivedActionBar
+            .takeIf { it.isNotEmpty() }
+            ?.let { player.sendActionBar(it.parse(mapOf("amount" to amountPretty))) }
         plugin.settingsConfig.mobCoinsSoundsPickup.play(player)
     }
 }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/RoseStackerListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/RoseStackerListener.kt
@@ -63,10 +63,12 @@ class RoseStackerListener(private val plugin: UltimateMobCoinsPlugin) : Listener
         if (!prepareMobCoinDropEvent.autoPickup) {
             for (entity1 in entityDrops.keySet()) {
                 for (drops in entityDrops[entity1]) {
-                    val dropAmount =
+                    var dropAmount =
                         plugin.mobCoinsManager.getCoinDropAmount(killer, mobCoin, dropsMultiplier) ?: continue
                     val mobCoinItem = plugin.mobCoinsManager.createMobCoinItem(dropAmount)
                     if (drops.drops.any { drop -> drop.type == mobCoinItem.type }) continue
+
+                    dropAmount = plugin.mobCoinsManager.checkRecentEarnings(killer, dropAmount)
 
                     val mobCoinDropEvent = MobCoinDropEvent(
                         killer,
@@ -93,6 +95,7 @@ class RoseStackerListener(private val plugin: UltimateMobCoinsPlugin) : Listener
             totalDropAmount += dropAmount
         }
         if (totalDropAmount == BigDecimal.ZERO) return
+        totalDropAmount = plugin.mobCoinsManager.checkRecentEarnings(killer, totalDropAmount)
 
         if (!MobCoinsReceiveEvent(killer, user, totalDropAmount, isAsynchronous).callEvent()) return
         user.depositCoins(totalDropAmount)

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/RoseStackerListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/RoseStackerListener.kt
@@ -65,10 +65,9 @@ class RoseStackerListener(private val plugin: UltimateMobCoinsPlugin) : Listener
                 for (drops in entityDrops[entity1]) {
                     var dropAmount =
                         plugin.mobCoinsManager.getCoinDropAmount(killer, mobCoin, dropsMultiplier) ?: continue
+                    dropAmount = plugin.mobCoinsManager.checkRecentEarnings(killer, dropAmount)
                     val mobCoinItem = plugin.mobCoinsManager.createMobCoinItem(dropAmount)
                     if (drops.drops.any { drop -> drop.type == mobCoinItem.type }) continue
-
-                    dropAmount = plugin.mobCoinsManager.checkRecentEarnings(killer, dropAmount)
 
                     val mobCoinDropEvent = MobCoinDropEvent(
                         killer,

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/CloudCommandManager.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/CloudCommandManager.kt
@@ -37,10 +37,6 @@ class CloudCommandManager(private val plugin: UltimateMobCoinsPlugin) {
             paperCommandManager.captionRegistry().apply {
                 registerProvider(CaptionProvider.constantProvider(StandardCaptionKeys.EXCEPTION_NO_PERMISSION, plugin.messagesConfig.noPermission))
                 registerProvider(CaptionProvider.forCaption(UltimateMobCoinsCaptionKeys.ARGUMENT_PARSE_FAILURE_MENU) { sender -> "Menu '{input}' does not exist!" })
-                /*registerProvider(CaptionProvider.forCaption(Caption.of("help.minecraft.help")) { sender -> plugin.messagesConfig.commandHelpTitle } )
-                registerProvider(CaptionProvider.forCaption(Caption.of("help.minecraft.showing_results_for_query")) { sender -> plugin.messagesConfig.commandHelpShowingResultsForQuery } )
-                registerProvider(CaptionProvider.forCaption(Caption.of("help.minecraft.no_results_for_query")) { sender -> plugin.messagesConfig.commandHelpNoResultsForQuery } )
-                registerProvider(CaptionProvider.forCaption(Caption.of("help.minecraft.available_commands")) { sender -> plugin.messagesConfig.commandHelpAvailableCommands } )*/
             }
 
             MinecraftExceptionHandler.createNative<CommandSender>()

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/HookManager.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/HookManager.kt
@@ -21,6 +21,8 @@ class HookManager(private val plugin: UltimateMobCoinsPlugin) : Listener {
     val roseStackerHook = RoseStackerHook(plugin)
     val headDatabaseHook = HeadDatabaseHook(plugin)
     val nexoHook = NexoHook(plugin)
+    val oraxenHook = OraxenHook(plugin)
+    val itemsAdderHook = ItemsAdderHook(plugin)
 
     fun load() {
         checkPlaceholderAPI()
@@ -32,6 +34,8 @@ class HookManager(private val plugin: UltimateMobCoinsPlugin) : Listener {
         roseStackerHook.load()
         headDatabaseHook.load()
         nexoHook.load()
+        oraxenHook.load()
+        itemsAdderHook.load()
     }
 
     fun unload() {
@@ -42,6 +46,8 @@ class HookManager(private val plugin: UltimateMobCoinsPlugin) : Listener {
         roseStackerHook.unload()
         headDatabaseHook.unload()
         nexoHook.unload()
+        oraxenHook.unload()
+        itemsAdderHook.unload()
     }
 
     private fun checkPlaceholderAPI() {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/HookManager.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/HookManager.kt
@@ -20,6 +20,7 @@ class HookManager(private val plugin: UltimateMobCoinsPlugin) : Listener {
     private val miniPlaceholdersHook = MiniPlaceholdersHook(plugin)
     val roseStackerHook = RoseStackerHook(plugin)
     val headDatabaseHook = HeadDatabaseHook(plugin)
+    val nexoHook = NexoHook(plugin)
 
     fun load() {
         checkPlaceholderAPI()
@@ -30,6 +31,7 @@ class HookManager(private val plugin: UltimateMobCoinsPlugin) : Listener {
         miniPlaceholdersHook.load()
         roseStackerHook.load()
         headDatabaseHook.load()
+        nexoHook.load()
     }
 
     fun unload() {
@@ -39,6 +41,7 @@ class HookManager(private val plugin: UltimateMobCoinsPlugin) : Listener {
         miniPlaceholdersHook.unload()
         roseStackerHook.unload()
         headDatabaseHook.unload()
+        nexoHook.unload()
     }
 
     private fun checkPlaceholderAPI() {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/MobCoinManager.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/MobCoinManager.kt
@@ -10,7 +10,6 @@ import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.pdc
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.setBoolean
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.setDouble
-import nl.chimpgamer.ultimatemobcoins.paper.listeners.EntityListener.EarningEntry
 import nl.chimpgamer.ultimatemobcoins.paper.models.MobCoin
 import nl.chimpgamer.ultimatemobcoins.paper.utils.NamespacedKeys
 import org.bukkit.entity.Player

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/MobCoinManager.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/MobCoinManager.kt
@@ -10,15 +10,51 @@ import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.pdc
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.setBoolean
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.setDouble
+import nl.chimpgamer.ultimatemobcoins.paper.listeners.EntityListener.EarningEntry
 import nl.chimpgamer.ultimatemobcoins.paper.models.MobCoin
 import nl.chimpgamer.ultimatemobcoins.paper.utils.NamespacedKeys
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import java.math.BigDecimal
+import java.math.MathContext
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 class MobCoinManager(private val plugin: UltimateMobCoinsPlugin) {
     val config: YamlDocument
     private val mobCoinsList = ArrayList<MobCoin>()
+
+    private val recentEarnings = mutableMapOf<String, MutableList<EarningEntry>>()
+
+    private data class EarningEntry(val amount: BigDecimal, val timestamp: Instant)
+
+    fun checkRecentEarnings(killer: Player, amount: BigDecimal): BigDecimal {
+        var dropAmount = amount
+        if (plugin.settingsConfig.mobCoinsEarningsPenaltyEnabled) {
+            val playerEarnings = recentEarnings.getOrPut(killer.uniqueId.toString()) { mutableListOf() }
+            val unit = ChronoUnit.valueOf(plugin.settingsConfig.mobCoinsEarningsPenaltyCooldownUnit.uppercase())
+            val ago = Instant.now().minus(plugin.settingsConfig.mobCoinsEarningsPenaltyCooldownValue, unit)
+            playerEarnings.removeIf { it.timestamp.isBefore(ago) }
+
+            val recentTotal = playerEarnings.sumOf { it.amount.toDouble() }
+            val earningsPenaltyThreshold = plugin.settingsConfig.mobCoinsEarningsPenaltyThreshold
+            if (recentTotal >= earningsPenaltyThreshold) {
+                val type = plugin.settingsConfig.mobCoinsEarningsPenaltyType
+                val value = plugin.settingsConfig.mobCoinsEarningsPenaltyValue
+                if (value <= 0) return dropAmount
+                if (type.equals("percentage", ignoreCase = true)) {
+                    // C * (V / 100)
+                    dropAmount = dropAmount.multiply(value.toBigDecimal().divide(100.toBigDecimal()))
+                } else if (type.equals("fixed", ignoreCase = true)) {
+                    dropAmount = value.toBigDecimal(MathContext(3))
+                } else return dropAmount
+            }
+
+            playerEarnings.add(EarningEntry(dropAmount, Instant.now()))
+        }
+
+        return dropAmount
+    }
 
     fun loadMobCoins() {
         mobCoinsList.clear()

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/MobCoin.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/MobCoin.kt
@@ -1,6 +1,7 @@
 package nl.chimpgamer.ultimatemobcoins.paper.models
 
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
+import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.Player
 import java.math.BigDecimal
 import java.math.MathContext
@@ -26,7 +27,7 @@ class MobCoin(
     fun getAmountToDrop(player: Player): BigDecimal {
         if (amount.isEmpty()) return BigDecimal.ZERO
         if (!willDropCoins()) return BigDecimal.ZERO
-        val lootingEnchantment = plugin.lootingEnchantment
+        val lootingEnchantment = Enchantment.LOOTING
 
         val hand = player.inventory.itemInMainHand
         if (amount[1] == 0.0) {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/Menu.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/Menu.kt
@@ -103,9 +103,9 @@ abstract class Menu(protected val plugin: UltimateMobCoinsPlugin, protected val 
             message = itemSection.getString("message"),
             permission = itemSection.getString("permission"),
             price = itemSection.getDouble("price", null),
-            priceVault = itemSection.getDouble("price-vault", itemSection.getDouble("price_vault", null),),
+            priceVault = itemSection.getDouble("price-vault", itemSection.getDouble("price_vault", null)),
             stock = itemSection.getInt("stock", null),
-            purchaseLimit = itemSection.getInt("purchase-limit", itemSection.getInt("purchase_limit", null),),
+            purchaseLimit = itemSection.getInt("purchase-limit", itemSection.getInt("purchase_limit", null)),
             chance = itemSection.getInt("chance", 0)
         )
         if (itemSection.contains("actions")) {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/Menu.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/Menu.kt
@@ -66,9 +66,12 @@ abstract class Menu(protected val plugin: UltimateMobCoinsPlugin, protected val 
 
     protected fun getItem(name: String) = menuItems.find { it.name.equals(name, ignoreCase = true) }
 
-    protected fun loadAllItems() {
-        menuItems.clear()
-        menuItems.addAll(getItemsFromConfig())
+    fun loadAllItems() {
+        val itemsFromConfig = getItemsFromConfig()
+        menuItems.apply {
+            clear()
+            addAll(itemsFromConfig)
+        }
     }
 
     protected fun getItemsFromConfig(): Set<MenuItem> {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/SpinnerMenu.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/SpinnerMenu.kt
@@ -137,7 +137,7 @@ class SpinnerMenu(private val plugin: UltimateMobCoinsPlugin) : InventoryProvide
     }.toList()
 
     private fun moveItems(contents: InventoryContents) {
-        val items = (FIRST_SLOT..LAST_SLOT - 1).map { 
+        val items = (FIRST_SLOT..<LAST_SLOT).map {
             contents[it].orElse(null)?.itemStack 
         }
         

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
@@ -2,10 +2,8 @@ package nl.chimpgamer.ultimatemobcoins.paper.utils
 
 import com.destroystokyo.paper.profile.ProfileProperty
 import dev.dejvokep.boostedyaml.block.implementation.Section
-import dev.lone.itemsadder.api.CustomStack
 import io.papermc.paper.registry.RegistryAccess
 import io.papermc.paper.registry.RegistryKey
-import io.th0rgal.oraxen.api.OraxenItems
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.*
@@ -13,7 +11,6 @@ import org.bukkit.Bukkit
 import org.bukkit.Color
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
-import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.ItemStack
@@ -42,8 +39,9 @@ object ItemUtils {
         if (itemSection.contains("oraxen")) {
             if (isOraxenEnabled) {
                 val oraxen = itemSection.getString("oraxen")
-                if (OraxenItems.exists(oraxen)) {
-                    itemStack = OraxenItems.getItemById(oraxen).build()
+                val oraxenItem = plugin.hookManager.oraxenHook.oraxenItem(oraxen)
+                if (oraxenItem != null) {
+                    itemStack = oraxenItem
                 } else {
                     plugin.logger.info("Could not find Oraxen item $oraxen")
                 }
@@ -54,9 +52,9 @@ object ItemUtils {
         if (itemSection.contains("itemsadder")) {
             if (isItemsAdderEnabled) {
                 val itemsadder = itemSection.getString("itemsadder")
-                val customStack = CustomStack.getInstance(itemsadder)
-                if (customStack != null) {
-                    itemStack = customStack.itemStack
+                val itemsAdderItem = plugin.hookManager.itemsAdderHook.itemsAdderItem(itemsadder)
+                if (itemsAdderItem != null) {
+                    itemStack = itemsAdderItem
                     itemStack.meta {
                         // For some reason ItemsAdder puts legacy color coding by default on the item?
                         displayName(displayName.parseLegacy())
@@ -132,8 +130,9 @@ object ItemUtils {
                 }
             } else if (name == "oraxen") {
                 if (isOraxenEnabled) {
-                    if (OraxenItems.exists(value)) {
-                        itemStack = OraxenItems.getItemById(value).build()
+                    val oraxenItem = plugin.hookManager.oraxenHook.oraxenItem(value)
+                    if (oraxenItem != null) {
+                        itemStack = oraxenItem
                     } else {
                         plugin.logger.info("Could not find Oraxen item $value")
                     }
@@ -142,9 +141,9 @@ object ItemUtils {
                 }
             } else if (name == "itemsadder") {
                 if (isItemsAdderEnabled) {
-                    val customStack = CustomStack.getInstance(value)
-                    if (customStack != null) {
-                        itemStack = customStack.itemStack
+                    val itemsAdderItem = plugin.hookManager.itemsAdderHook.itemsAdderItem(value)
+                    if (itemsAdderItem != null) {
+                        itemStack = itemsAdderItem
                         itemStack.meta {
                             // For some reason ItemsAdder puts legacy color coding by default on the item?
                             displayName(displayName.parseLegacy())

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
@@ -154,6 +154,17 @@ object ItemUtils {
                 } else {
                     plugin.logger.info("Could not use ItemsAdder. ItemsAdder is not installed or enabled!")
                 }
+            } else if (name == "nexo") {
+                if (isNexoEnabled) {
+                    val nexoItem = NexoItems.itemFromId(value)
+                    if (nexoItem != null) {
+                        itemStack = nexoItem.build()
+                    } else {
+                        plugin.logger.info("Could not find nexo item $value")
+                    }
+                } else {
+                    plugin.logger.info("Could not use nexo. nexo is not installed or enabled!")
+                }
             } else if (name == "amount") {
                 val amount = value.toIntOrNull()
                 if (amount != null) {
@@ -198,10 +209,16 @@ object ItemUtils {
                 }
             } else if (name == "potion") {
                 if (itemStack.itemMeta is PotionMeta) {
+                    val potionParts = value.split("#")
+
+                    val potionTypeName = potionParts[0].trim()
+                    val extended = potionParts[1].trim().toBooleanStrictOrNull() ?: false
+                    val upgraded = potionParts[2].trim().toBooleanStrictOrNull() ?: false
+
                     val potionType =
-                        PotionType.entries.firstOrNull { value.equals(it.name, ignoreCase = true) }
+                        PotionType.entries.firstOrNull { potionTypeName.equals(it.name, ignoreCase = true) }
                     if (potionType != null) {
-                        itemStack = itemStack.potion(potionType)
+                        itemStack = itemStack.potion(potionType, extended, upgraded)
                     }
                 }
             } else if (name == "color") {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
@@ -198,16 +198,10 @@ object ItemUtils {
                 }
             } else if (name == "potion") {
                 if (itemStack.itemMeta is PotionMeta) {
-                    val potionParts = value.split("#")
-
-                    val potionTypeName = potionParts[0].trim()
-                    val extended = potionParts[1].trim().toBooleanStrictOrNull() ?: false
-                    val upgraded = potionParts[2].trim().toBooleanStrictOrNull() ?: false
-
                     val potionType =
-                        PotionType.entries.firstOrNull { potionTypeName.equals(it.name, ignoreCase = true) }
+                        PotionType.entries.firstOrNull { value.equals(it.name, ignoreCase = true) }
                     if (potionType != null) {
-                        itemStack = itemStack.potion(potionType, extended, upgraded)
+                        itemStack = itemStack.potion(potionType)
                     }
                 }
             } else if (name == "color") {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
@@ -209,16 +209,10 @@ object ItemUtils {
                 }
             } else if (name == "potion") {
                 if (itemStack.itemMeta is PotionMeta) {
-                    val potionParts = value.split("#")
-
-                    val potionTypeName = potionParts[0].trim()
-                    val extended = potionParts[1].trim().toBooleanStrictOrNull() ?: false
-                    val upgraded = potionParts[2].trim().toBooleanStrictOrNull() ?: false
-
                     val potionType =
-                        PotionType.entries.firstOrNull { potionTypeName.equals(it.name, ignoreCase = true) }
+                        PotionType.entries.firstOrNull { value.equals(it.name, ignoreCase = true) }
                     if (potionType != null) {
-                        itemStack = itemStack.potion(potionType, extended, upgraded)
+                        itemStack = itemStack.potion(potionType)
                     }
                 }
             } else if (name == "color") {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
@@ -3,6 +3,8 @@ package nl.chimpgamer.ultimatemobcoins.paper.utils
 import com.destroystokyo.paper.profile.ProfileProperty
 import dev.dejvokep.boostedyaml.block.implementation.Section
 import dev.lone.itemsadder.api.CustomStack
+import io.papermc.paper.registry.RegistryAccess
+import io.papermc.paper.registry.RegistryKey
 import io.th0rgal.oraxen.api.OraxenItems
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
@@ -73,7 +75,7 @@ object ItemUtils {
                 if (nexoItem != null) {
                     itemStack = nexoItem
                 } else {
-                    plugin.logger.info("Could not find nexo item $nexo. Perhaps the nexo items are not loaded yet?")
+                    plugin.logger.info("Could not find nexo item $nexo for ${itemSection.nameAsString}. Perhaps the nexo items are not loaded yet?")
                 }
             } else {
                 plugin.logger.info("Could not use nexo. Nexo is not installed or enabled!")
@@ -159,7 +161,7 @@ object ItemUtils {
                     if (nexoItem != null) {
                         itemStack = nexoItem
                     } else {
-                        plugin.logger.info("Could not find nexo item $value")
+                        plugin.logger.info("Could not find nexo item $value. Perhaps the nexo items are not loaded yet?")
                     }
                 } else {
                     plugin.logger.info("Could not use nexo. nexo is not installed or enabled!")
@@ -202,7 +204,8 @@ object ItemUtils {
                 val level = enchantmentParts[1].trim().toIntOrNull() ?: -1
 
                 val enchantment =
-                    runCatching { Enchantment.getByKey(NamespacedKey.minecraft(enchantmentName)) }.getOrNull()
+                    runCatching { RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT)
+                        .get(NamespacedKey.minecraft(enchantmentName)) }.getOrNull()
                 if (enchantment != null) {
                     itemStack = itemStack.enchantment(enchantment, level)
                 }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
@@ -1,7 +1,6 @@
 package nl.chimpgamer.ultimatemobcoins.paper.utils
 
 import com.destroystokyo.paper.profile.ProfileProperty
-import com.nexomc.nexo.api.NexoItems
 import dev.dejvokep.boostedyaml.block.implementation.Section
 import dev.lone.itemsadder.api.CustomStack
 import io.th0rgal.oraxen.api.OraxenItems
@@ -25,7 +24,7 @@ import java.util.UUID
 object ItemUtils {
     private val isOraxenEnabled: Boolean get() = Bukkit.getPluginManager().isPluginEnabled("Oraxen")
     private val isItemsAdderEnabled: Boolean get() = Bukkit.getPluginManager().isPluginEnabled("ItemsAdder")
-    private val isNexoEnabled: Boolean get() = Bukkit.getPluginManager().isPluginEnabled("nexo")
+    private val isNexoEnabled: Boolean get() = Bukkit.getPluginManager().isPluginEnabled("Nexo")
 
     private val skullOwnerNamespacedKey = NamespacedKey("ultimatemobcoins", "skull_owner")
 
@@ -70,14 +69,14 @@ object ItemUtils {
         if (itemSection.contains("nexo")) {
             if (isNexoEnabled) {
                 val nexo = itemSection.getString("nexo")
-                val nexoItem = NexoItems.itemFromId(nexo)
+                val nexoItem = plugin.hookManager.nexoHook.nexoItem(nexo)
                 if (nexoItem != null) {
-                    itemStack = nexoItem.build()
+                    itemStack = nexoItem
                 } else {
-                    plugin.logger.info("Could not find nexo item $nexo")
+                    plugin.logger.info("Could not find nexo item $nexo. Perhaps the nexo items are not loaded yet?")
                 }
             } else {
-                plugin.logger.info("Could not use nexo. nexo is not installed or enabled!")
+                plugin.logger.info("Could not use nexo. Nexo is not installed or enabled!")
             }
         }
         if (itemSection.contains("name")) {
@@ -156,9 +155,9 @@ object ItemUtils {
                 }
             } else if (name == "nexo") {
                 if (isNexoEnabled) {
-                    val nexoItem = NexoItems.itemFromId(value)
+                    val nexoItem = plugin.hookManager.nexoHook.nexoItem(value)
                     if (nexoItem != null) {
-                        itemStack = nexoItem.build()
+                        itemStack = nexoItem
                     } else {
                         plugin.logger.info("Could not find nexo item $value")
                     }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/NumberFormatter.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/NumberFormatter.kt
@@ -32,7 +32,7 @@ object NumberFormatter {
     fun displayCurrency(value: BigDecimal?): String {
         var str = PRETTY_FORMAT.format(value)
         if (str.endsWith(".00")) {
-            str = str.substring(0, str.length - 3)
+            str = str.dropLast(3)
         }
         return str
     }

--- a/paper/src/main/resources/hooks.yml
+++ b/paper/src/main/resources/hooks.yml
@@ -4,8 +4,11 @@ EcoMobs:
   enabled: true
 HeadDatabase:
   enabled: true
+# Added placeholders to MiniPlaceholders v3
+# MiniPlaceholders v2 is not supported!
 MiniPlaceholders:
-  enabled: true
+  # This is 'false' by default because v3 of MiniPlaceholders is only compatible with 1.21+
+  enabled: false
 MythicMobs:
   enabled: true
 PlaceholderAPI:

--- a/paper/src/main/resources/hooks.yml
+++ b/paper/src/main/resources/hooks.yml
@@ -4,11 +4,8 @@ EcoMobs:
   enabled: true
 HeadDatabase:
   enabled: true
-# Added placeholders to MiniPlaceholders v3
-# MiniPlaceholders v2 is not supported!
 MiniPlaceholders:
-  # This is 'false' by default because v3 of MiniPlaceholders is only compatible with 1.21+
-  enabled: false
+  enabled: true
 MythicMobs:
   enabled: true
 PlaceholderAPI:

--- a/paper/src/main/resources/hooks.yml
+++ b/paper/src/main/resources/hooks.yml
@@ -4,6 +4,8 @@ EcoMobs:
   enabled: true
 HeadDatabase:
   enabled: true
+Nexo:
+  enabled: true
 MiniPlaceholders:
   enabled: true
 MythicMobs:
@@ -19,4 +21,4 @@ Vault:
 WorldGuard:
   enabled: true
 
-config-version: 3
+config-version: 4

--- a/paper/src/main/resources/hooks.yml
+++ b/paper/src/main/resources/hooks.yml
@@ -4,11 +4,15 @@ EcoMobs:
   enabled: true
 HeadDatabase:
   enabled: true
-Nexo:
+ItemsAdder:
   enabled: true
 MiniPlaceholders:
   enabled: true
 MythicMobs:
+  enabled: true
+Nexo:
+  enabled: true
+Oraxen:
   enabled: true
 PlaceholderAPI:
   enabled: true

--- a/paper/src/main/resources/paper-plugin.yml
+++ b/paper/src/main/resources/paper-plugin.yml
@@ -44,7 +44,7 @@ dependencies:
   - name: HeadDatabase
     required: false
     bootstrap: false
-  - name: nexo
+  - name: Nexo
     required: false
     bootstrap: false
   - name: eco

--- a/paper/src/main/resources/paper-plugin.yml
+++ b/paper/src/main/resources/paper-plugin.yml
@@ -1,7 +1,7 @@
 name: UltimateMobCoins
 main: nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
 version: ${version}
-api-version: '1.19'
+api-version: '1.21'
 authors:
   - ChimpGamer
 folia-supported: true

--- a/paper/src/main/resources/settings.yml
+++ b/paper/src/main/resources/settings.yml
@@ -67,6 +67,16 @@ mobcoins:
   leaderboard:
     enabled: false
     show-zero: false
+  earnings-penalty:
+    enabled: false
+    threshold: 1000.0
+    per:
+      value: 1
+      unit: minutes
+    # Type options: PERCENTAGE or FIXED
+    type: percentage
+    # Value supports decimals. So 2.25 is 2.25% or 2.25 coins depending on the type set above.
+    value: 0.0
 
 log:
   pay: true

--- a/paper/src/main/resources/settings.yml
+++ b/paper/src/main/resources/settings.yml
@@ -89,8 +89,12 @@ command:
   aliases:
     - mobcoin
   default_shop: main_menu
+  withdraw:
+    # When disabled, the amount will always be converted to a integer.
+    # Changing this setting requires a server restart.
+    amount-double-type: true
 
 update:
   notify-on-join: true
 
-config-version: 9
+config-version: 10


### PR DESCRIPTION
Changes:
- Dropped support for 1.19 and 1.20. Use (v1 if you use 1.19 or 1.20)
- Added support for MiniPlaceholders v3. This drops support for MiniPlaceholders v2. The MiniPlaceholders hook is also disabled by default to minimize initial issues when installing the plugin with MiniPlaceholders v2.
- Added shop_with_timer.yml to the shop files list. (Fixed missing shop issue)
- Bump Kotlin version to 2.2.10.
- Added a configurable withdraw amount type (double or integer)
- Fixed nexo support not working in the shop menus.
- Improved loading the menu items.
- Potion now uses potion type only. If you use potions please check this in your configuration because it will cause issues.
- Improved support for oraxen en itemsadder.
- Added nexo, itemsadder and oraxen to the hooks.yml.
- Bumped HikariCP to 7.0.2.
- Bumped MariaDB Java Client to 3.5.6.