### PR TITLE
v2.0.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "nl.chimpgamer.ultimatemobcoins"
-    version = "2.0.1"
+    version = "2.0.2-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "nl.chimpgamer.ultimatemobcoins"
-    version = "2.0.2-SNAPSHOT"
+    version = "2.0.2"
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,7 @@ subprojects {
     }
 
     repositories {
-        maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
-            name = "sonatype-oss-snapshots"
-        }
+        mavenLocal()
     }
 
     dependencies {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsPlugin.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/UltimateMobCoinsPlugin.kt
@@ -141,6 +141,7 @@ class UltimateMobCoinsPlugin : SuspendingJavaPlugin() {
 
         registerEvents(
             FireworkListener(),
+            PlayerInventoryListener(this),
             hookManager
         )
         registerSuspendingEvents(

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/commands/MobCoinsCommand.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/commands/MobCoinsCommand.kt
@@ -1,6 +1,7 @@
 package nl.chimpgamer.ultimatemobcoins.paper.commands
 
 import com.github.shynixn.mccoroutine.folia.asyncDispatcher
+import com.github.shynixn.mccoroutine.folia.globalRegionDispatcher
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.feature.pagination.Pagination
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
@@ -19,6 +20,7 @@ import org.bukkit.OfflinePlayer
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 import org.incendo.cloud.CommandManager
+import org.incendo.cloud.bukkit.parser.PlayerParser.playerParser
 import org.incendo.cloud.component.CommandComponent
 import org.incendo.cloud.component.DefaultValue
 import org.incendo.cloud.key.CloudKey
@@ -575,6 +577,23 @@ class MobCoinsCommand(private val plugin: UltimateMobCoinsPlugin) {
                 sender.sendMessage(plugin.messagesConfig.mobCoinsGiveSender.parse(replacements))
                 if (!isSilent)
                     targetPlayer.player?.sendMessage(plugin.messagesConfig.mobCoinsGiveTarget.parse(replacements))
+            }
+        )
+
+        commandManager.command(builder
+            .literal("redeem")
+            .optional(playerKey, playerParser())
+            .permission("$basePermission.redeem")
+            .suspendingHandler(context = plugin.globalRegionDispatcher) { context ->
+                val sender = context.sender()
+                val player = context[playerKey]
+                val playerInventory = player.inventory
+                playerInventory.contents
+                    .filterNotNull()
+                    .forEach { itemStack ->
+                        plugin.mobCoinsManager.redeemMobCoinItem(player, itemStack)
+                    }
+                sender.sendRichMessage("<green>Redeemed all mob coin items from ${player.name}'s inventory!")
             }
         )
     }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/MenuConfig.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/MenuConfig.kt
@@ -29,13 +29,13 @@ class MenuConfig(plugin: UltimateMobCoinsPlugin, val file: File) {
 
     fun getString(route: String, def: String?): String? = config.getString(route, def)
 
-    fun getBoolean(route: String): Boolean = config.getBoolean(route)
+    fun getBoolean(route: String, def: Boolean? = null): Boolean = config.getBoolean(route, def)
 
     fun getInt(route: String, def: Int): Int = config.getInt(route, def)
 
-    fun getLong(route: String): Long? = config.getLong(route)
+    fun getLong(route: String, def: Long? = null): Long? = config.getLong(route, def)
 
-    fun getIntList(route: String): List<Int> = config.getIntList(route)
+    fun getIntList(route: String, def: List<Int> = emptyList()): List<Int> = config.getIntList(route, def)
 
     fun <T : Enum<T>> getEnum(route: String, clazz: KClass<T>, def: T): T = config.getEnum(route, clazz.java, def)
 

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/MenuConfig.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/MenuConfig.kt
@@ -29,7 +29,8 @@ class MenuConfig(plugin: UltimateMobCoinsPlugin, val file: File) {
 
     fun getString(route: String, def: String?): String? = config.getString(route, def)
 
-    fun getBoolean(route: String, def: Boolean? = null): Boolean = config.getBoolean(route, def)
+    fun getBoolean(route: String): Boolean = config.getBoolean(route)
+    fun getBoolean(route: String, def: Boolean): Boolean = config.getBoolean(route, def)
 
     fun getInt(route: String, def: Int): Int = config.getInt(route, def)
 

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/SettingsConfig.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/SettingsConfig.kt
@@ -33,14 +33,16 @@ class SettingsConfig(private val plugin: UltimateMobCoinsPlugin) {
 
     val mobCoinsDisabledWorlds: List<String> get() = config.getStringList("mobcoins.disabled_worlds")
     val mobCoinsStartingBalance: Double get() = config.getDouble("mobcoins.starting_balance")
-    val mobCoinsAutoPickup: Boolean get() = config.getBoolean("mobcoins.auto-pickup", false)
+    val mobCoinsDropsAutoRedeemOnPickup: Boolean get() = config.getBoolean("mobcoins.drops.auto-redeem-on-pickup", true)
+    val mobCoinsDropsAutoPickup: Boolean get() = config.getBoolean("mobcoins.drops.auto-pickup", false)
+    val mobCoinsDropsAllowHopperPickup: Boolean get() = config.getBoolean("mobcoins.drops.allow-hopper-pickup", false)
     val mobCoinsFormat: String get() = config.getString("mobcoins.format")
     val mobCoinsFormatLocale: String get() = config.getString("mobcoins.format-locale")
     fun getMobCoinsItem(tagResolver: TagResolver) = ItemUtils.itemSectionToItemStack(plugin, config.getSection("mobcoins.item"), tagResolver)
+    val mobCoinsItemSelfRedeemable: Boolean get() = config.getBoolean("mobcoins.item.self-redeemable", true)
     val mobCoinsSoundsDrop: ConfigurableSound get() = ConfigurableSound.deserialize(config.getSection("mobcoins.sounds.drop").getStringRouteMappedValues(false))
     val mobCoinsSoundsPickup: ConfigurableSound get() = ConfigurableSound.deserialize(config.getSection("mobcoins.sounds.pickup").getStringRouteMappedValues(false))
     val mobCoinsLootingEnchantMultiplier: Boolean get() = config.getBoolean("mobcoins.looting-enchant-multiplier", true)
-    val mobCoinsAllowHopperPickup: Boolean get() = config.getBoolean("mobcoins.allow-hopper-pickup", false)
     val mobCoinsLossOnDeathType: String get() = config.getString("mobcoins.loss-on-death.type")
     val mobCoinsLossOnDeathValue: Double get() = config.getDouble("mobcoins.loss-on-death.value")
     val mobCoinsLeaderboardEnabled: Boolean get() = config.getBoolean("mobcoins.leaderboard.enabled", false)
@@ -85,5 +87,16 @@ class SettingsConfig(private val plugin: UltimateMobCoinsPlugin) {
         }
 
         NumberFormatter.setPrettyFormat(mobCoinsFormat, mobCoinsFormatLocale)
+
+        if (config.contains("mobcoins.auto-pickup")) {
+            val mobCoinsAutoPickup = config.getBoolean("mobcoins.auto-pickup")
+            config.set("mobcoins.drops.auto-pickup", mobCoinsAutoPickup)
+            config.set("mobcoins.auto-pickup", null)
+        }
+        if (config.contains("mobcoins.allow-hopper-pickup")) {
+            val mobCoinsAllowHopperPickup = config.getBoolean("mobcoins.allow-hopper-pickup")
+            config.set("mobcoins.drops.allow-hopper-pickup", mobCoinsAllowHopperPickup)
+            config.set("mobcoins.allow-hopper-pickup", null)
+        }
     }
 }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/SpinnerConfig.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/configurations/SpinnerConfig.kt
@@ -11,9 +11,9 @@ import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
 class SpinnerConfig(plugin: UltimateMobCoinsPlugin) {
     private val config: YamlDocument
 
-    val shootFireworks: Boolean get() = config.getBoolean("shoot_fireworks")
-    val usageCosts: Double get() = config.getDouble("usage_costs")
-    val menuTitle: String get() = config.getString("menu_title")
+    val shootFireworks: Boolean get() = config.getBoolean("shoot-fireworks", config.getBoolean("shoot_fireworks"))
+    val usageCosts: Double get() = config.getDouble("usage-costs", config.getDouble("usage_costs"))
+    val menuTitle: String get() = config.getString("title", config.getString("menu_title"))
 
     init {
         val fileName = "spinner.yml"

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/EntityListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/EntityListener.kt
@@ -64,7 +64,7 @@ class EntityListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
         val mobCoin = plugin.mobCoinsManager.getMobCoin(entityTypeName) ?: return
         mobCoin.applyDropChanceMultiplier(killer)
         val dropsMultiplier = plugin.getMobCoinDropsMultiplier(killer)
-        val autoPickup = plugin.settingsConfig.mobCoinsAutoPickup && killer.hasPermission("ultimatemobcoins.autopickup")
+        val autoPickup = plugin.settingsConfig.mobCoinsDropsAutoPickup && killer.hasPermission("ultimatemobcoins.autopickup")
 
         val prepareMobCoinDropEvent = PrepareMobCoinDropEvent(
             killer,
@@ -120,7 +120,7 @@ class EntityListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
                 mobCoinsAnimationDrop.play(entity)
             }
         }
-        if (plugin.settingsConfig.mobCoinsAllowHopperPickup) return
+        if (plugin.settingsConfig.mobCoinsDropsAllowHopperPickup) return
         entity.setMetadata("NO_PICKUP", FixedMetadataValue(plugin, true)) // UpgradableHoppers support
     }
 }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/EntityListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/EntityListener.kt
@@ -109,10 +109,8 @@ class EntityListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     fun ItemSpawnEvent.onItemSpawn() {
         val itemStack = entity.itemStack
-        if (!itemStack.hasItemMeta()) return
-        itemStack.itemMeta.pdc {
-            if (!has(NamespacedKeys.isMobCoin) || !getBoolean(NamespacedKeys.isMobCoin)) return
-        }
+        val isMobCoinItem = plugin.mobCoinsManager.isMobCoinItem(itemStack)
+        if (!isMobCoinItem) return
         val mobCoinsAnimationDrop = plugin.settingsConfig.mobCoinsAnimationsDrop
         if (mobCoinsAnimationDrop.enabled) {
             plugin.launch(plugin.entityDispatcher(entity)) {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/ItemPickupListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/ItemPickupListener.kt
@@ -29,10 +29,8 @@ class ItemPickupListener(private val plugin: UltimateMobCoinsPlugin) : Listener 
         if (inventory.type !== InventoryType.HOPPER) return
         if (plugin.settingsConfig.mobCoinsDropsAllowHopperPickup) return
         val itemStack = item.itemStack
-        if (!itemStack.hasItemMeta()) return
-        itemStack.itemMeta.pdc {
-            if (!has(NamespacedKeys.isMobCoin) || !getBoolean(NamespacedKeys.isMobCoin)) return
-        }
+        val isMobCoinItem = plugin.mobCoinsManager.isMobCoinItem(itemStack)
+        if (!isMobCoinItem) return
         isCancelled = true
     }
 }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/ItemPickupListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/ItemPickupListener.kt
@@ -1,61 +1,33 @@
 package nl.chimpgamer.ultimatemobcoins.paper.listeners
 
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
-import nl.chimpgamer.ultimatemobcoins.paper.events.MobCoinsReceiveEvent
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.getBoolean
-import nl.chimpgamer.ultimatemobcoins.paper.extensions.getDouble
-import nl.chimpgamer.ultimatemobcoins.paper.extensions.parse
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.pdc
 import nl.chimpgamer.ultimatemobcoins.paper.utils.NamespacedKeys
-import nl.chimpgamer.ultimatemobcoins.paper.utils.NumberFormatter
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.inventory.InventoryPickupItemEvent
 import org.bukkit.event.inventory.InventoryType
 import org.bukkit.event.player.PlayerAttemptPickupItemEvent
-import java.math.BigDecimal
 
 class ItemPickupListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
 
     @EventHandler(ignoreCancelled = true)
     suspend fun PlayerAttemptPickupItemEvent.onPlayerAttemptPickupItem() {
+        if (!plugin.settingsConfig.mobCoinsDropsAutoRedeemOnPickup) return
         val itemStack = item.itemStack
-        if (!itemStack.hasItemMeta()) return
-        var amount = BigDecimal.ZERO
-        itemStack.itemMeta.pdc {
-            if (!has(NamespacedKeys.isMobCoin) || !getBoolean(NamespacedKeys.isMobCoin)) return
-            amount = getDouble(NamespacedKeys.mobCoinAmount)?.toBigDecimal() ?: return
-        }
+        val isMobCoinItem = plugin.mobCoinsManager.isMobCoinItem(itemStack)
+        if (!isMobCoinItem) return
         isCancelled = true
-
-        amount = amount.multiply(itemStack.amount.toBigDecimal())
         item.remove()
-
-        // Deposit coins
-
-        val user = plugin.userManager.getIfLoaded(player)
-        if (user == null) {
-            plugin.logger.warning("Something went wrong! Could not get user ${player.name} (${player.uniqueId})")
-            return
-        }
-        if (!MobCoinsReceiveEvent(player, user, amount).callEvent()) return
-        user.depositCoins(amount)
-        user.addCoinsCollected(amount)
-        val amountPretty = NumberFormatter.displayCurrency(amount)
-        plugin.messagesConfig.mobCoinsReceivedChat
-            .takeIf { it.isNotEmpty() }
-            ?.let { player.sendMessage(it.parse(mapOf("amount" to amountPretty))) }
-        plugin.messagesConfig.mobCoinsReceivedActionBar
-            .takeIf { it.isNotEmpty() }
-            ?.let { player.sendActionBar(it.parse(mapOf("amount" to amountPretty))) }
-        plugin.settingsConfig.mobCoinsSoundsPickup.play(player)
+        plugin.mobCoinsManager.redeemMobCoinItem(player, itemStack)
     }
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     fun InventoryPickupItemEvent.onInventoryPickupItem() {
         if (inventory.type !== InventoryType.HOPPER) return
-        if (plugin.settingsConfig.mobCoinsAllowHopperPickup) return
+        if (plugin.settingsConfig.mobCoinsDropsAllowHopperPickup) return
         val itemStack = item.itemStack
         if (!itemStack.hasItemMeta()) return
         itemStack.itemMeta.pdc {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/ItemPickupListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/ItemPickupListener.kt
@@ -1,9 +1,6 @@
 package nl.chimpgamer.ultimatemobcoins.paper.listeners
 
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
-import nl.chimpgamer.ultimatemobcoins.paper.extensions.getBoolean
-import nl.chimpgamer.ultimatemobcoins.paper.extensions.pdc
-import nl.chimpgamer.ultimatemobcoins.paper.utils.NamespacedKeys
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
@@ -15,7 +12,38 @@ class ItemPickupListener(private val plugin: UltimateMobCoinsPlugin) : Listener 
 
     @EventHandler(ignoreCancelled = true)
     suspend fun PlayerAttemptPickupItemEvent.onPlayerAttemptPickupItem() {
-        if (!plugin.settingsConfig.mobCoinsDropsAutoRedeemOnPickup) return
+        if (!plugin.settingsConfig.mobCoinsDropsAutoRedeemOnPickup) {
+            val itemStack = item.itemStack
+            val isMobCoinItem = plugin.mobCoinsManager.isMobCoinItem(itemStack)
+            if (!isMobCoinItem) return
+
+            val playerInventory = player.inventory
+            val mobCoinItemsInInventory = playerInventory.storageContents
+                .withIndex()
+                .filter { it.value != null }
+                .filter { plugin.mobCoinsManager.isMobCoinItem(it.value!!) }
+
+            if (mobCoinItemsInInventory.isEmpty()) return
+
+            var cancel = false
+
+            val valueToAdd = plugin.mobCoinsManager.getMobCoinValue(itemStack) ?: return
+
+            for ((pos, mobCoinItem) in mobCoinItemsInInventory) {
+                val mobCoinValue = plugin.mobCoinsManager.getMobCoinValue(mobCoinItem!!) ?: continue
+                if (mobCoinValue >= 1000.toBigDecimal()) continue
+                if (mobCoinValue + valueToAdd >= 1000.toBigDecimal()) continue // Does it fit in another existing coin?
+                cancel = true
+
+                playerInventory.setItem(pos, plugin.mobCoinsManager.createMobCoinItem(mobCoinValue + valueToAdd))
+                break
+            }
+            if (cancel) {
+                isCancelled = true
+                item.remove()
+            }
+            return
+        }
         val itemStack = item.itemStack
         val isMobCoinItem = plugin.mobCoinsManager.isMobCoinItem(itemStack)
         if (!isMobCoinItem) return

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/PlayerInteractListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/PlayerInteractListener.kt
@@ -1,19 +1,11 @@
 package nl.chimpgamer.ultimatemobcoins.paper.listeners
 
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
-import nl.chimpgamer.ultimatemobcoins.paper.events.MobCoinsRedeemEvent
-import nl.chimpgamer.ultimatemobcoins.paper.extensions.getBoolean
-import nl.chimpgamer.ultimatemobcoins.paper.extensions.getDouble
-import nl.chimpgamer.ultimatemobcoins.paper.extensions.parse
-import nl.chimpgamer.ultimatemobcoins.paper.extensions.pdc
-import nl.chimpgamer.ultimatemobcoins.paper.utils.NamespacedKeys
-import nl.chimpgamer.ultimatemobcoins.paper.utils.NumberFormatter
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.inventory.EquipmentSlot
-import java.math.BigDecimal
 
 class PlayerInteractListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
 
@@ -22,32 +14,10 @@ class PlayerInteractListener(private val plugin: UltimateMobCoinsPlugin) : Liste
         if (hand !== EquipmentSlot.HAND) return
         if (!(action === Action.RIGHT_CLICK_BLOCK || action === Action.RIGHT_CLICK_AIR)) return
         val itemInHand = item ?: return
-        if (!itemInHand.hasItemMeta()) return
-        var amount = BigDecimal.ZERO
-        itemInHand.itemMeta.pdc {
-            if (!has(NamespacedKeys.isMobCoin) || !getBoolean(NamespacedKeys.isMobCoin)) return
-            amount = getDouble(NamespacedKeys.mobCoinAmount)?.toBigDecimal() ?: return
-        }
+        val isMobCoinItem = plugin.mobCoinsManager.isMobCoinItem(itemInHand)
+        if (!isMobCoinItem) return
+        if (!plugin.settingsConfig.mobCoinsItemSelfRedeemable) return
         isCancelled = true
-
-        // Deposit amount
-        amount = amount.multiply(itemInHand.amount.toBigDecimal())
-
-        val user = plugin.userManager.getIfLoaded(player)
-        if (user == null) {
-            plugin.logger.warning("Something went wrong! Could not get user ${player.name} (${player.uniqueId})")
-            return
-        }
-        if (!MobCoinsRedeemEvent(player, user, amount).callEvent()) return
-        user.depositCoins(amount)
-        player.inventory.setItemInMainHand(null)
-        val amountPretty = NumberFormatter.displayCurrency(amount)
-        plugin.messagesConfig.mobCoinsReceivedChat
-            .takeIf { it.isNotEmpty() }
-            ?.let { player.sendMessage(it.parse(mapOf("amount" to amountPretty))) }
-        plugin.messagesConfig.mobCoinsReceivedActionBar
-            .takeIf { it.isNotEmpty() }
-            ?.let { player.sendActionBar(it.parse(mapOf("amount" to amountPretty))) }
-        plugin.settingsConfig.mobCoinsSoundsPickup.play(player)
+        plugin.mobCoinsManager.redeemMobCoinItem(player, itemInHand)
     }
 }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/PlayerInventoryListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/PlayerInventoryListener.kt
@@ -1,0 +1,46 @@
+package nl.chimpgamer.ultimatemobcoins.paper.listeners
+
+import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.InventoryAction
+import org.bukkit.event.inventory.InventoryClickEvent
+
+class PlayerInventoryListener(private val plugin: UltimateMobCoinsPlugin) : Listener {
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onInventoryClick(event: InventoryClickEvent) {
+        if (!isValidMergeAction(event)) return
+        val currentItem = event.currentItem ?: return
+        val cursor = event.cursor
+
+        if (cursor.type != currentItem.type) return
+
+        val player = event.whoClicked as Player
+
+        val mobCoinManager = plugin.mobCoinsManager
+        if (!mobCoinManager.isMobCoinItem(cursor)) return
+        if (!mobCoinManager.isMobCoinItem(currentItem)) return
+
+        event.isCancelled = true
+
+        val value1 = mobCoinManager.getMobCoinValue(cursor) ?: return
+        val value2 = mobCoinManager.getMobCoinValue(currentItem) ?: return
+
+        val newItem = mobCoinManager.createMobCoinItem(value1 + value2)
+        event.currentItem = newItem
+
+        player.setItemOnCursor(null)
+    }
+
+    private fun isValidMergeAction(event: InventoryClickEvent): Boolean {
+        return when (event.action) {
+            InventoryAction.PLACE_ALL,
+            InventoryAction.PLACE_ONE,
+            InventoryAction.SWAP_WITH_CURSOR -> true
+            else -> false
+        }
+    }
+}

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/RoseStackerListener.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/listeners/RoseStackerListener.kt
@@ -47,7 +47,7 @@ class RoseStackerListener(private val plugin: UltimateMobCoinsPlugin) : Listener
         val entityTypeName = plugin.hookManager.getEntityName(entity)
         val mobCoin = plugin.mobCoinsManager.getMobCoin(entityTypeName) ?: return
         mobCoin.applyDropChanceMultiplier(killer)
-        val autoPickup = plugin.settingsConfig.mobCoinsAutoPickup && killer.hasPermission("ultimatemobcoins.autopickup")
+        val autoPickup = plugin.settingsConfig.mobCoinsDropsAutoPickup && killer.hasPermission("ultimatemobcoins.autopickup")
         val dropsMultiplier = plugin.getMobCoinDropsMultiplier(killer)
 
         val prepareMobCoinDropEvent = PrepareMobCoinDropEvent(

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/MobCoinManager.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/MobCoinManager.kt
@@ -89,7 +89,7 @@ class MobCoinManager(private val plugin: UltimateMobCoinsPlugin) {
     }
 
     fun createMobCoinItem(dropAmount: BigDecimal): ItemStack {
-        val mobCoinItem = plugin.settingsConfig.getMobCoinsItem(Placeholder.unparsed("amount", dropAmount.toString())) // EpicHoppers ignores the item if the name starts with *** (https://github.com/craftaro/EpicHoppers/blob/master/EpicHoppers-Plugin/src/main/java/com/craftaro/epichoppers/hopper/levels/modules/ModuleSuction.java#L97)
+        val mobCoinItem = plugin.settingsConfig.getMobCoinsItem(Placeholder.unparsed("amount", NumberFormatter.displayCurrency(dropAmount))) // EpicHoppers ignores the item if the name starts with *** (https://github.com/craftaro/EpicHoppers/blob/master/EpicHoppers-Plugin/src/main/java/com/craftaro/epichoppers/hopper/levels/modules/ModuleSuction.java#L97)
 
         mobCoinItem.editMeta { meta ->
             meta.pdc {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/MobCoinManager.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/MobCoinManager.kt
@@ -7,11 +7,16 @@ import dev.dejvokep.boostedyaml.settings.loader.LoaderSettings
 import dev.dejvokep.boostedyaml.settings.updater.UpdaterSettings
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
 import nl.chimpgamer.ultimatemobcoins.paper.UltimateMobCoinsPlugin
+import nl.chimpgamer.ultimatemobcoins.paper.events.MobCoinsRedeemEvent
+import nl.chimpgamer.ultimatemobcoins.paper.extensions.getBoolean
+import nl.chimpgamer.ultimatemobcoins.paper.extensions.getDouble
+import nl.chimpgamer.ultimatemobcoins.paper.extensions.parse
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.pdc
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.setBoolean
 import nl.chimpgamer.ultimatemobcoins.paper.extensions.setDouble
 import nl.chimpgamer.ultimatemobcoins.paper.models.MobCoin
 import nl.chimpgamer.ultimatemobcoins.paper.utils.NamespacedKeys
+import nl.chimpgamer.ultimatemobcoins.paper.utils.NumberFormatter
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import java.math.BigDecimal
@@ -57,9 +62,9 @@ class MobCoinManager(private val plugin: UltimateMobCoinsPlugin) {
 
     fun loadMobCoins() {
         mobCoinsList.clear()
-        val mobCoinDrops = config.getSection("mobCoinDrops") ?: return
+        val mobCoinDrops = config.getSection("mobcoin-drops", config.getSection("mobCoinDrops")) ?: return
         mobCoinDrops.keys.mapNotNull { it.toString() }.forEach { key ->
-            val entityType = key.uppercase()
+            val entityType = key.uppercase().replace("-", "_")
             val chance = mobCoinDrops.getDouble("$key.chance")
             val amountStr = mobCoinDrops.getString("$key.amount")
 
@@ -94,6 +99,41 @@ class MobCoinManager(private val plugin: UltimateMobCoinsPlugin) {
         }
 
         return mobCoinItem
+    }
+
+    fun isMobCoinItem(itemStack: ItemStack) = itemStack.hasItemMeta() && itemStack.itemMeta.pdc.has(NamespacedKeys.isMobCoin) && itemStack.itemMeta.pdc.getBoolean(NamespacedKeys.isMobCoin)
+
+    fun getMobCoinValue(itemStack: ItemStack): BigDecimal? {
+        var amount = BigDecimal.ZERO
+        val mobCoinsAmount = itemStack.itemMeta.pdc.getDouble(NamespacedKeys.mobCoinAmount)
+        if (mobCoinsAmount != null) amount = mobCoinsAmount.toBigDecimal()
+        return amount.multiply(itemStack.amount.toBigDecimal())
+    }
+
+    suspend fun redeemMobCoinItem(player: Player, itemStack: ItemStack) {
+        var amount = BigDecimal.ZERO
+        itemStack.itemMeta.pdc {
+            amount = getDouble(NamespacedKeys.mobCoinAmount)?.toBigDecimal() ?: return
+        }
+
+        amount = amount.multiply(itemStack.amount.toBigDecimal())
+
+        val user = plugin.userManager.getIfLoaded(player)
+        if (user == null) {
+            plugin.logger.warning("Something went wrong! Could not get user ${player.name} (${player.uniqueId})")
+            return
+        }
+        if (!MobCoinsRedeemEvent(player, user, amount).callEvent()) return
+        user.depositCoins(amount)
+        player.inventory.removeItemAnySlot(itemStack)
+        val amountPretty = NumberFormatter.displayCurrency(amount)
+        plugin.messagesConfig.mobCoinsReceivedChat
+            .takeIf { it.isNotEmpty() }
+            ?.let { player.sendMessage(it.parse(mapOf("amount" to amountPretty))) }
+        plugin.messagesConfig.mobCoinsReceivedActionBar
+            .takeIf { it.isNotEmpty() }
+            ?.let { player.sendActionBar(it.parse(mapOf("amount" to amountPretty))) }
+        plugin.settingsConfig.mobCoinsSoundsPickup.play(player)
     }
 
     fun reload() {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/SpinnerManager.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/managers/SpinnerManager.kt
@@ -37,7 +37,7 @@ class SpinnerManager(private val plugin: UltimateMobCoinsPlugin) {
                 ?.getStringRouteMappedValues(false)
                 ?.let(ConfigurableSound::deserialize)
 
-            prizeWonSound = soundsSection.getSection("prize_won")
+            prizeWonSound = soundsSection.getSection("prize-won", soundsSection.getSection("prize_won"))
                 ?.getStringRouteMappedValues(false)
                 ?.let(ConfigurableSound::deserialize)
         }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/Menu.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/Menu.kt
@@ -297,9 +297,9 @@ abstract class Menu(protected val plugin: UltimateMobCoinsPlugin, protected val 
     init {
         title = config.getString("title", "MobCoin Shop")
         permission = config.getString("permission")
-        closeOnClick = config.getBoolean("close_on_click")
+        closeOnClick = config.getBoolean("close-on-click", config.getBoolean("close_on_click"))
 
-        updateInterval = config.getInt("update_interval", DEFAULT_UPDATE_INTERVAL)
+        updateInterval = config.getInt("update-interval", config.getInt("update_interval", DEFAULT_UPDATE_INTERVAL))
         if (updateInterval > 0) updateInterval * 50
 
         inventorySize = config.getInt("size", DEFAULT_INVENTORY_SIZE)

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/RefreshableShopMenu.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/RefreshableShopMenu.kt
@@ -33,7 +33,7 @@ abstract class RefreshableShopMenu(plugin: UltimateMobCoinsPlugin, config: MenuC
     }
 
     fun resetTimeRemaining() {
-        val refreshTime = config.getLong("refresh_time")
+        val refreshTime = config.getLong("refresh-time", config.getLong("refresh_time"))
         if (refreshTime == null || refreshTime <= 0) return
         this.refreshTime = Instant.now().plusSeconds(refreshTime)
     }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/RotatingShopMenu.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/RotatingShopMenu.kt
@@ -55,11 +55,13 @@ class RotatingShopMenu(plugin: UltimateMobCoinsPlugin, config: MenuConfig) : Ref
     override fun refresh() {
         refreshShopItems()
         resetTimeRemaining()
+        plugin.logger.info("[${file.name}] Refreshed shop menu")
+        plugin.logWriter.writeAsync("[${file.name}] Refreshed shop menu")
     }
 
     override fun refreshShopItems() {
         currentShopItems.clear()
-        val shopSlots = config.getIntList("shop_slots")
+        val shopSlots = config.getIntList("shop-slots", config.getIntList("shop_slots"))
         plugin.debug { "[${file.name}] shopSlots=$shopSlots" }
         val shopItems = this.allRotatingShopItems.filter { it.success }.map { it.clone() }.toMutableList()
         for (slot in shopSlots) {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/ShopMenu.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/models/menu/ShopMenu.kt
@@ -55,6 +55,8 @@ class ShopMenu(plugin: UltimateMobCoinsPlugin, config: MenuConfig) : Refreshable
     override fun refresh() {
         refreshShopItems()
         resetTimeRemaining()
+        plugin.logger.info("[${file.name}] Refreshed shop menu")
+        plugin.logWriter.writeAsync("[${file.name}] Refreshed shop menu")
     }
 
     override fun refreshShopItems() {

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/ItemUtils.kt
@@ -91,8 +91,8 @@ object ItemUtils {
             val glow = itemSection.getBoolean("glow")
             itemStack.glow(glow)
         }
-        if (itemSection.contains("model_data")) {
-            val modelData = itemSection.getInt("model_data", null)
+        if (itemSection.contains("model_data") || itemSection.contains("model-data")) {
+            val modelData = itemSection.getInt("model_data", itemSection.getInt("model-data", null))
             if (modelData != null) {
                 itemStack.customModelData(modelData)
             }

--- a/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/updatechecker/ModrinthUpdateChecker.kt
+++ b/paper/src/main/kotlin/nl/chimpgamer/ultimatemobcoins/paper/utils/updatechecker/ModrinthUpdateChecker.kt
@@ -39,7 +39,7 @@ class ModrinthUpdateChecker(private val plugin: UltimateMobCoinsPlugin) {
     }
 
     fun notifyAboutUpdate() {
-        val latestRelease = updates.first { it.versionType == RELEASE_VERSION_TYPE }
+        val latestRelease = updates.firstOrNull { it.versionType == RELEASE_VERSION_TYPE } ?: return
         val latestVersion = Version(latestRelease.versionNumber)
         val pluginVersion = Version(plugin.version)
         if (pluginVersion >= latestVersion) return
@@ -49,7 +49,7 @@ class ModrinthUpdateChecker(private val plugin: UltimateMobCoinsPlugin) {
     fun notifyPlayerAboutUpdate(player: Player) {
         if (!plugin.settingsConfig.updateNotifyOnJoin) return
         if (!player.hasPermission("ultimatemobcoins.update-check")) return
-        val latestRelease = updates.first { it.versionType == RELEASE_VERSION_TYPE }
+        val latestRelease = updates.firstOrNull { it.versionType == RELEASE_VERSION_TYPE } ?: return
         val latestVersion = Version(latestRelease.versionNumber)
         val pluginVersion = Version(plugin.version)
         if (pluginVersion >= latestVersion) return

--- a/paper/src/main/resources/mobcoins.yml
+++ b/paper/src/main/resources/mobcoins.yml
@@ -1,7 +1,7 @@
-# For a list of all entity types check: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html
+# For a list of all entity types check: https://jd.papermc.io/paper/org/bukkit/entity/EntityType.html
 # Chances are between 0-100. This means you have a chance between 0 and 100 percent
 # Amount supports decimals and ranges.
-mobCoinDrops:
+mobcoin-drops:
   elder_guardian:
     chance: 5
     amount: 10

--- a/paper/src/main/resources/settings.yml
+++ b/paper/src/main/resources/settings.yml
@@ -25,7 +25,10 @@ mobcoins:
   disabled_worlds:
     - disabled_world
   starting_balance: 0.0
-  auto-pickup: false
+  drops:
+    auto-redeem-on-pickup: true
+    auto-pickup: false
+    allow-hopper-pickup: false
   format: '###,##0.00'
   format-locale: 'en-US'
   item:
@@ -39,7 +42,9 @@ mobcoins:
       - <reset>
       - <gray>Right click to redeem!
     glow: false
-    model_data: null
+    model-data: null
+    # Players can redeem their coins by clicking on the item.
+    self-redeemable: true
   sounds:
     drop:
       enabled: true
@@ -58,7 +63,6 @@ mobcoins:
       particle: SPELL_WITCH
       duration: 10
   looting-enchant-multiplier: true
-  allow-hopper-pickup: false
   loss-on-death:
     # Type options: PERCENTAGE or FIXED
     type: percentage
@@ -90,11 +94,11 @@ command:
     - mobcoin
   default_shop: main_menu
   withdraw:
-    # When disabled, the amount will always be converted to a integer.
+    # When disabled, the amount will always be converted to an integer.
     # Changing this setting requires a server restart.
     amount-double-type: true
 
 update:
   notify-on-join: true
 
-config-version: 10
+config-version: 11

--- a/paper/src/main/resources/shops/main_menu.yml
+++ b/paper/src/main/resources/shops/main_menu.yml
@@ -1,8 +1,8 @@
 title: MobCoin Shops
 type: NORMAL
 size: 9
-close_on_click: false
-update_interval: 20 # Set to 0 if you don't want the inventory to update itself every x ticks.
+close-on-click: false
+update-interval: 20 # Set to 0 if you don't want the inventory to update itself every x ticks.
 sounds:
   opening:
     enabled: true

--- a/paper/src/main/resources/shops/rotating_shop.yml
+++ b/paper/src/main/resources/shops/rotating_shop.yml
@@ -1,10 +1,10 @@
 title: Rotating MobCoin Shop
 type: ROTATING_SHOP
 size: 36
-close_on_click: false
-update_interval: 20
-shop_slots: [12, 13, 14, 15, 16, 21, 22, 23, 24, 25]
-refresh_time: 86400
+close-on-click: false
+update-interval: 20
+shop-slots: [12, 13, 14, 15, 16, 21, 22, 23, 24, 25]
+refresh-time: 86400
 sounds:
   opening:
     enabled: true

--- a/paper/src/main/resources/shops/shop.yml
+++ b/paper/src/main/resources/shops/shop.yml
@@ -1,8 +1,8 @@
 title: MobCoin Shop
 type: SHOP
 size: 36
-close_on_click: false
-update_interval: 0 # Prevents the inventory from unnecessary updating
+close-on-click: false
+update-interval: 0 # Prevents the inventory from unnecessary updating
 sounds:
   opening:
     enabled: true

--- a/paper/src/main/resources/shops/shop_with_timer.yml
+++ b/paper/src/main/resources/shops/shop_with_timer.yml
@@ -1,9 +1,9 @@
 title: MobCoin Shop with Timer
 type: SHOP
 size: 36
-close_on_click: false
-update_interval: 20
-refresh_time: 86400
+close-on-click: false
+update-interval: 20
+refresh-time: 86400
 sounds:
   opening:
     enabled: true

--- a/paper/src/main/resources/spinner.yml
+++ b/paper/src/main/resources/spinner.yml
@@ -1,13 +1,13 @@
-shoot_fireworks: true
-usage_costs: 250.0
-menu_title: <gold><bold>MobCoin Spinner
+title: <gold><bold>MobCoin Spinner
+shoot-fireworks: true
+usage-costs: 250.0
 sounds:
   spinning:
     enabled: true
     sound: UI_BUTTON_CLICK
     volume: 1.0
     pitch: 1.0
-  prize_won:
+  prize-won:
     enabled: true
     sound: ENTITY_PLAYER_LEVELUP
     volume: 1.0


### PR DESCRIPTION
Changes:
- Added redeem command to redeem all mobcoins in the player inventory (/mobcoins redeem)
- Added new settings regarding drops and redeeming mobcoins.
- Improved compatibility with older configuration files.
- Allow merging of mobcoins by dragging a mobcoin onto another mobcoin in a inventory.
- Properly format the <amount> placeholder on a mobcoin item.
- Log when a shop is refreshed.
- Fixed NPE in the update checker when modrinth is unavailable.
- Removed some duplicated code.